### PR TITLE
dead letter queue being declared

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -221,18 +221,10 @@ class RabbitMQ():
         connection = self.get_connection()
         channel = connection.channel()
 
-        exchange_args = {}
-
         # declare dead letter exchange if needed
         if dead_letter_exchange:
-            dead_letter_exchange_name = 'dead.letter.{}'.format(
-                self.exchange_name)
+            dead_letter_exchange_name = f'dead.letter.{self.exchange_name}'
             channel.exchange_declare(dead_letter_exchange_name, 'direct')
-
-            exchange_args = {
-                'x-dead-letter-exchange': dead_letter_exchange_name,
-                'x-dead-letter-routing-key': routing_key
-            }
 
         # Declare exchange
         channel.exchange_declare(
@@ -240,8 +232,9 @@ class RabbitMQ():
 
         # Creates new queue or connects to existing one
         queue_name = self.queue_prefix + '.' + func.__name__.replace('_', '.')
+        exchange_args = {}
         if dead_letter_exchange and not self.development:
-            dead_letter_queue_name = 'dead.letter.{}'.format(queue_name)
+            dead_letter_queue_name = f'dead.letter.{queue_name}'
             channel.queue_declare(
                 dead_letter_queue_name,
                 durable=self.queue_params.durable,
@@ -263,7 +256,7 @@ class RabbitMQ():
             exclusive=self.queue_params.exclusive,
             arguments=exchange_args
         )
-        self.app.logger.info('Declaring Queue: {}'.format(queue_name))
+        self.app.logger.info(f'Declaring Queue: {queue_name}')
 
         # Bind queue to exchange
         channel.queue_bind(exchange=self.exchange_name,


### PR DESCRIPTION
Queue being declared for dead letter exchange. It starts being populated after the queue callback is unable to process the message.

To test this you must change the enviroment to production.