### PR TITLE
add ability to get environment variables not only from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install and update using [pip](https://pip.pypa.io/en/stable/quickstart/):
     pip install rabbitmq-pika-flask
 ```
 
-Add the following variables to your environment
+Add the following variables to your environment or the Flask settings:
 
 - FLASK*ENV=Flask environment, such as \_production* or _development_
 - MQ_EXCHANGE=Your exchange name

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -94,11 +94,12 @@ class RabbitMQ():
                 parse messages to be sent. Defaults to None.
         """
 
-        self._check_env()
-
         self.app = app
         self.queue_prefix = queue_prefix
         self.config = app.config
+
+        self._check_env()
+
         self.body_parser = body_parser
         self.msg_parser = msg_parser
         self.development = development
@@ -131,15 +132,15 @@ class RabbitMQ():
         """assert env variables are set
         """
 
-        assert os.getenv(
-            'FLASK_ENV') is not None, 'No FLASK_ENV variable found. Add one such as "production" or "development"'
+        assert any((os.getenv('FLASK_ENV'), self.config['FLASK_ENV'])) \
+               is not None, 'No FLASK_ENV variable found. Add one such as "production" or "development"'
 
-        assert os.getenv(
-            'MQ_URL') is not None, 'No MQ_URL variable found. Please add one following this' + \
-            ' format https://pika.readthedocs.io/en/stable/examples/using_urlparameters.html'
+        assert any((os.getenv('MQ_URL'), self.config['MQ_URL'])) \
+               is not None, 'No MQ_URL variable found. Please add one following this' + \
+               ' format https://pika.readthedocs.io/en/stable/examples/using_urlparameters.html'
 
-        assert os.getenv(
-            'MQ_EXCHANGE') is not None, 'No MQ_EXCHANGE variable found. Please add a default exchange'
+        assert any((os.getenv('MQ_EXCHANGE'), self.config['MQ_EXCHANGE'])) \
+               is not None, 'No MQ_EXCHANGE variable found. Please add a default exchange'
 
     def queue(
         self,


### PR DESCRIPTION
but also from Flask settings.

**Why I think it's needed?**
I am getting `AssertionError: No MQ_URL variable found. Please add one following this format https://pika.readthedocs.io/en/stable/examples/using_urlparameters.html` if I configure MQ_URL in Flask settings module. Configuring such kind of variables in Flask settings module is common. Also RabbitMQ url might be composited from separate environment variables like vhost, user and password.

**Solution:** If RabbitMQ checks the settings after gets the configs from the app then it may check not only environment variables but also app configs.