### PR TITLE
add custom delimiter

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -130,7 +130,8 @@ class RabbitMQ():
     def _build_queue_name(self, func: Callable):
         """Builds queue name from function name"""
 
-        return self.queue_prefix + '.' + func.__name__.replace('_', '.')
+        spacer = self.config['MQ_DELIMITER'] if 'MQ_DELIMITER' in self.config else '.'
+        return self.queue_prefix + spacer + func.__name__.replace('_', spacer)
 
     def queue(
         self,


### PR DESCRIPTION
This change adding custom delimiter for queue name. 
It`s can improve usability when U integrating with many existing queues.
We need add config parameter MQ_DELIMITER = '_'. If not setted - used '.' as default