### PR TITLE
Fixes_Issue#30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='rabbitmq_pika_flask',
     packages=['rabbitmq_pika_flask'],   # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version='1.2.9',
+    version='1.2.10',
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license='MIT',
     # Give a short description about your library

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='rabbitmq_pika_flask',
     packages=['rabbitmq_pika_flask'],   # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version='1.2.10',
+    version='1.2.11',
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license='MIT',
     # Give a short description about your library


### PR DESCRIPTION
Context:

When dead letter queues are declared from queues that have the same routing key, dead letter messages that originate from one queue are routed two both dead letter queues

Changes:

- dead letter queues are declared with binding: `routing key = dead letter queue name`
- dead lettered messages are published to dead letter exchange with `routing key = dead letter queue name`

