### PR TITLE
Pass dlq_name to error callback

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -18,9 +18,9 @@ from retry.api import retry_call
 from rabbitmq_pika_flask.ExchangeType import ExchangeType
 from rabbitmq_pika_flask.QueueParams import QueueParams
 
-
+# (queue_name, dlq_name, method, props, body, exception)
 MessageErrorCallback = Callable[
-    [str, spec.Basic.Deliver, spec.BasicProperties, str, Exception], Any
+    [str, Union[str, None], spec.Basic.Deliver, spec.BasicProperties, str, Exception], Any
 ]
 
 
@@ -352,8 +352,9 @@ class RabbitMQ:
                             )
                     finally:
                         if self.on_message_error_callback is not None:
+                            dlq_name = dead_letter_queue_name if dead_letter_exchange else None
                             self.on_message_error_callback(
-                                queue_name, method, props, decoded_body, err
+                                queue_name, dlq_name, method, props, decoded_body, err
                             )
 
         channel.basic_consume(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.20",
+    version="1.2.21",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
I added the dlq name to the error callback arguments.

This breaks compatibility with the previous version, released last week. Are we okay doing this?

It's unlikely anyone is already using the callback feature.