### PR TITLE
Fix error callback in development

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -282,6 +282,7 @@ class RabbitMQ:
         # Creates new queue or connects to existing one
         queue_name = self._build_queue_name(func)
         exchange_args = {}
+        dead_letter_queue_name = None
         if dead_letter_exchange and not self.development:
             dead_letter_queue_name = f"dead.letter.{queue_name}"
             channel.queue_declare(
@@ -352,9 +353,8 @@ class RabbitMQ:
                             )
                     finally:
                         if self.on_message_error_callback is not None:
-                            dlq_name = dead_letter_queue_name if dead_letter_exchange else None
                             self.on_message_error_callback(
-                                queue_name, dlq_name, method, props, decoded_body, err
+                                queue_name, dead_letter_queue_name, method, props, decoded_body, err
                             )
 
         channel.basic_consume(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.21",
+    version="1.2.22",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
Error callback does not work in development because we only set `dead_letter_queue_name` if `not self.development`.

This PR fixes it by setting a default value for `dead_letter_queue_name` (None).