### PR TITLE
Extract needed props from function signature when props_needed is not provided

### DIFF
--- a/examples/basic/src/events/PingEvents.py
+++ b/examples/basic/src/events/PingEvents.py
@@ -1,7 +1,7 @@
 from examples.basic.src.services.rabbit import rabbit
 
 
-@rabbit.queue(routing_key='ping.*', dead_letter_exchange=True, props_needed=["message_id"])
+@rabbit.queue(routing_key='ping.*', dead_letter_exchange=True)
 def ping_event(routing_key, body, message_id):
     print('Message received:')
     print('\tKey: {}'.format(routing_key))

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -236,7 +236,7 @@ class RabbitMQ:
 
         payload = {}
 
-        if "message_id" in props_needed:
+        if not props_needed or "message_id" in props_needed:
             payload["message_id"] = props.message_id
 
         if "sent_at" in props_needed:

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -1,6 +1,8 @@
+import inspect
 import json
 import os
 from datetime import datetime
+from enum import Enum, auto
 from functools import wraps
 from hashlib import sha256
 from threading import Thread
@@ -22,6 +24,14 @@ from rabbitmq_pika_flask.QueueParams import QueueParams
 MessageErrorCallback = Callable[
     [str, Union[str, None], spec.Basic.Deliver, spec.BasicProperties, str, Exception], Any
 ]
+
+
+class OptionalProps(Enum):
+    """Props that can be optionally passed to functions decorated by @queue."""
+
+    message_id = auto()
+    sent_at = auto()
+    message_version = auto()
 
 
 class RabbitMQ:
@@ -174,6 +184,12 @@ class RabbitMQ:
                 os.getenv("FLASK_ENV") == "production"
                 or os.getenv("WERKZEUG_RUN_MAIN") == "true"
             ):
+                nonlocal props_needed
+                if props_needed is None:
+                    f_signature = inspect.signature(f).parameters
+                    props_needed = [
+                        prop.name for prop in OptionalProps if prop.name in f_signature
+                    ]
 
                 @wraps(f)
                 def new_consumer():

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -252,7 +252,7 @@ class RabbitMQ:
 
         payload = {}
 
-        if not props_needed or "message_id" in props_needed:
+        if "message_id" in props_needed:
             payload["message_id"] = props.message_id
 
         if "sent_at" in props_needed:


### PR DESCRIPTION
Fixes #28

This was the behavior before https://github.com/aylton-almeida/rabbitmq-pika-flask/commit/af6ab788b2ba4049b6aefa11be5db7f2d8b17f15.
Otherwise apps with queues based off of older version would have to change all their queue definitions.
I've kept the behavior when props_needed is passed, but changed it to add message_id when it's not.
