### PR TITLE
add x-message-version header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ docs/_build/
 .env
 
 .vscode
+.idea

--- a/examples/basic/src/events/PingEvents.py
+++ b/examples/basic/src/events/PingEvents.py
@@ -1,7 +1,7 @@
 from ..services.rabbit import rabbit
 
 
-@rabbit.queue(routing_key='ping.*', dead_letter_exchange=True)
+@rabbit.queue(routing_key='ping.*', dead_letter_exchange=True, props_needed=["message_id"])
 def ping_event(routing_key, body, message_id):
     print('Message received:')
     print('\tKey: {}'.format(routing_key))

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -242,6 +242,9 @@ class RabbitMQ:
         if "sent_at" in props_needed:
             payload["sent_at"] = datetime.fromtimestamp(props.timestamp)
 
+        if "message_version" in props_needed:
+            payload["message_version"] = props.headers.get("x-message-version")
+
         return payload
 
     @retry((AMQPConnectionError, AssertionError), delay=5, jitter=(5, 15))
@@ -301,7 +304,7 @@ class RabbitMQ:
                 "x-dead-letter-exchange": dead_letter_exchange_name,
                 "x-dead-letter-routing-key": dead_letter_queue_name,
             }
-            
+
         channel.queue_declare(
             queue_name,
             durable=self.queue_params.durable,
@@ -370,7 +373,7 @@ class RabbitMQ:
 
             raise AMQPConnectionError from err
 
-    def _send_msg(self, body, routing_key, exchange_type):
+    def _send_msg(self, body, routing_key, exchange_type, message_version: str = "v1.0.0"):
         try:
             channel = self.get_connection().channel()
 
@@ -389,7 +392,7 @@ class RabbitMQ:
                 routing_key=routing_key,
                 body=body,
                 properties=spec.BasicProperties(
-                    message_id=message_id, timestamp=timestamp
+                    message_id=message_id, timestamp=timestamp, headers={"x-message-version": message_version}
                 ),
             )
 
@@ -406,6 +409,7 @@ class RabbitMQ:
         routing_key: str,
         exchange_type: ExchangeType = ExchangeType.DEFAULT,
         retries: int = 5,
+        message_version: str = "v1.0.0"
     ):
         """Sends a message to a given routing key
 
@@ -418,7 +422,7 @@ class RabbitMQ:
         thread = Thread(
             target=lambda: retry_call(
                 self._send_msg,
-                (body, routing_key, exchange_type),
+                (body, routing_key, exchange_type, message_version),
                 exceptions=(AMQPConnectionError, AssertionError),
                 tries=retries,
                 delay=5,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.22",
+    version="1.2.23",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
### Proposal for new version 1.2.23

**Add x-message-version to header when you want to change the body of some event without having to create a new one, so you can add the deserialize logic for each message-version**

This new property is not mandatory, since it will be included by default if you put `message_version` in the `props_needed`

This is how props looks like when message-version is sent at `rabbit.send(body='ping', routing_key='ping.message', retries=3, message_version="v2.0.0")` by the producer
```
props  {'content_type': None, 'content_encoding': None, 'headers': {'x-message-version': 'v2.0.0'}, 'delivery_mode': None, 'priority': None, 'correlation_id': None, 'reply_to': None, 'expiration': None, 'message_id': '94adb30aaa28d378068cd2ed88363b9248db133f30d4d1b4da79b4cdd86a80c2', 'timestamp': 1660150284, 'type': None, 'user_id': None, 'app_id': None, 'cluster_id': None}
```

And this is how the message is received by the consumer
```
Message received:
        Key: ping.message
        Body: ping
        Message: 94adb30aaa28d378068cd2ed88363b9248db133f30d4d1b4da79b4cdd86a80c2
        Version: v2.0.0
```



