### PR TITLE
When props_needed is not passed, extract props from signature

### DIFF
--- a/examples/basic/src/events/PingEvents.py
+++ b/examples/basic/src/events/PingEvents.py
@@ -1,7 +1,7 @@
 from examples.basic.src.services.rabbit import rabbit
 
 
-@rabbit.queue(routing_key='ping.*', dead_letter_exchange=True, props_needed=["message_id"])
+@rabbit.queue(routing_key='ping.*', dead_letter_exchange=True)
 def ping_event(routing_key, body, message_id):
     print('Message received:')
     print('\tKey: {}'.format(routing_key))


### PR DESCRIPTION
A fix to https://github.com/aylton-almeida/rabbitmq-pika-flask/issues/28

We can't just go back to passing `message_id` by default, as that would break it for anyone using [1.2.16](https://github.com/aylton-almeida/rabbitmq-pika-flask/releases/tag/1.2.16) or newer versions.

This solution works for everyone. If `props_needed` is not passed, look at the function signature to decide which props need to be passed.