### PR TITLE
Create wheel when building release version through github action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,5 +26,5 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python setup.py sdist
+          python setup.py sdist bdist_wheel
           twine upload --skip-existing dist/*

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.25",
+    version="1.2.26",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
I was confident the github action would use deploy.sh, so I didn't check, but it doesn't. So also changing the github action.