### PR TITLE
Set thread daemon attribute directly instead of using setDaemon

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -243,7 +243,7 @@ class RabbitMQ:
             )
 
         thread = Thread(target=create_queue, name=self._build_queue_name(func))
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
     @staticmethod
@@ -447,7 +447,7 @@ class RabbitMQ:
                 jitter=(5, 15),
             )
         )
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
     def sync_send(


### PR DESCRIPTION
This was officially deprecated in python-3.10[1] and setting the daemon attribute directly has been support for long enough that it won't break older supported versions.

[1] https://github.com/python/cpython/pull/25174