### PR TITLE
Add support for middlewares

### DIFF
--- a/rabbitmq_pika_flask/RabbitConsumerMessage.py
+++ b/rabbitmq_pika_flask/RabbitConsumerMessage.py
@@ -1,0 +1,51 @@
+import itertools
+from typing import Any, Callable, Iterator
+from pika import spec
+
+
+CallNext = Callable[["RabbitConsumerMessage"], Any]
+RabbitConsumerMiddleware = Callable[["RabbitConsumerMessage", CallNext], Any]
+
+
+class RabbitConsumerMiddlewareError(RuntimeError):
+    """Raised when a middleware results in an unexpected error. This is raised by the
+    code that handles middlewares; not raised by the middlewares themselves."""
+
+
+class RabbitConsumerMessage:
+    def __init__(
+        self,
+        routing_key: str,
+        raw_body: bytes,
+        parsed_body: Any,
+        method: spec.Basic.Deliver,
+        props: spec.BasicProperties,
+    ) -> None:
+        self.routing_key = routing_key
+        self.raw_body = raw_body
+        self.parsed_body = parsed_body
+        self.method = method
+        self.props = props
+
+    def call_middlewares(self, middlewares: Iterator[RabbitConsumerMiddleware]) -> None:
+        """Calls middlewares with this message. Each middleware is *expected* to call
+        `call_next` once, and exactly once; this is not enforced."""
+
+        middlewares_iter = itertools.chain(
+            middlewares, [lambda message, call_next: None]
+        )
+
+        def call_next(message: RabbitConsumerMessage) -> None:
+            try:
+                middleware = next(middlewares_iter)
+            except StopIteration as e:
+                # We can't be 100% sure which middleware did this
+                raise RabbitConsumerMiddlewareError(
+                    "Middleware called `call_next` twice."
+                )
+            middleware(message, call_next)
+
+        call_next(self)
+
+    def __str__(self) -> str:
+        return str(self.__dict__)

--- a/rabbitmq_pika_flask/RabbitConsumerMessage.py
+++ b/rabbitmq_pika_flask/RabbitConsumerMessage.py
@@ -3,8 +3,10 @@ from typing import Any, Callable, Iterator
 from pika import spec
 
 
-CallNext = Callable[["RabbitConsumerMessage"], Any]
-RabbitConsumerMiddleware = Callable[["RabbitConsumerMessage", CallNext], Any]
+RabbitConsumerMiddlewareCallNext = Callable[["RabbitConsumerMessage"], Any]
+RabbitConsumerMiddleware = Callable[
+    ["RabbitConsumerMessage", RabbitConsumerMiddlewareCallNext], Any
+]
 
 
 class RabbitConsumerMiddlewareError(RuntimeError):

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -1,4 +1,5 @@
 import inspect
+import itertools
 import json
 import os
 from datetime import datetime
@@ -19,6 +20,7 @@ from retry.api import retry_call
 
 from rabbitmq_pika_flask.ExchangeType import ExchangeType
 from rabbitmq_pika_flask.QueueParams import QueueParams
+from rabbitmq_pika_flask.RabbitConsumerMessage import RabbitConsumerMessage, RabbitConsumerMiddleware
 
 # (queue_name, dlq_name, method, props, body, exception)
 MessageErrorCallback = Callable[
@@ -51,6 +53,7 @@ class RabbitMQ:
     queue_params: QueueParams
 
     on_message_error_callback: Union[MessageErrorCallback, None]
+    middlewares: List[RabbitConsumerMiddleware]
 
     def __init__(
         self,
@@ -61,10 +64,12 @@ class RabbitMQ:
         queue_params: QueueParams = QueueParams(),
         development: bool = False,
         on_message_error_callback: Union[MessageErrorCallback, None] = None,
+        middlewares: Union[List[RabbitConsumerMiddleware], None] = None,
     ) -> None:
         self.app = None
         self.consumers = set()
         self.queue_params = queue_params
+        self.middlewares = middlewares or []
 
         if app is not None:
             self.init_app(
@@ -85,6 +90,7 @@ class RabbitMQ:
         msg_parser: Callable = lambda msg: msg,
         development: bool = False,
         on_message_error_callback: Union[MessageErrorCallback, None] = None,
+        middlewares: Union[List[RabbitConsumerMiddleware], None] = None,
     ):
         """This callback can be used to initialize an application for the use with this RabbitMQ setup.
 
@@ -98,6 +104,8 @@ class RabbitMQ:
             development (bool, optional): If the app is in development mode. Defaults to False.
             on_message_error_callback (Callable, optional): Function that's called when the processing of
                 a message fails due to an exception.
+            middlewares: List of callables that are called, in order, to process a rabbitmq
+                message received from the queue, before finally calling the user consumer func.
         """
 
         self.app = app
@@ -111,6 +119,8 @@ class RabbitMQ:
         self.development = development
         self.exchange_name = self.config["MQ_EXCHANGE"]
         self.on_message_error_callback = on_message_error_callback
+        self.middlewares.extend(middlewares or [])
+
         params = URLParameters(self.config["MQ_URL"])
         self.get_connection = lambda: BlockingConnection(params)
 
@@ -339,6 +349,15 @@ class RabbitMQ:
             exchange=self.exchange_name, queue=queue_name, routing_key=routing_key
         )
 
+        def user_consumer(message: RabbitConsumerMessage, call_next) -> None:
+            """User consumer as a middleware. Calls the consumer `func`."""
+            func(
+                routing_key=message.routing_key,
+                body=message.parsed_body,
+                **RabbitMQ.__get_needed_props(props_needed, message.props),
+            )
+            call_next(message)
+
         def callback(
             _: BlockingChannel,
             method: spec.Basic.Deliver,
@@ -356,10 +375,11 @@ class RabbitMQ:
                         x_death_props = props.headers.get("x-death")[0]
                         routing_key = x_death_props.get("routing-keys")[0]
 
-                    func(
-                        routing_key=routing_key,
-                        body=self.body_parser(decoded_body),
-                        **RabbitMQ.__get_needed_props(props_needed, props),
+                    message = RabbitConsumerMessage(
+                        routing_key, body, self.body_parser(decoded_body), method, props
+                    )
+                    message.call_middlewares(
+                        itertools.chain(list(self.middlewares), [user_consumer])
                     )
 
                     if not auto_ack:

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -20,7 +20,11 @@ from retry.api import retry_call
 
 from rabbitmq_pika_flask.ExchangeType import ExchangeType
 from rabbitmq_pika_flask.QueueParams import QueueParams
-from rabbitmq_pika_flask.RabbitConsumerMessage import RabbitConsumerMessage, RabbitConsumerMiddleware
+from rabbitmq_pika_flask.RabbitConsumerMiddleware import (
+    RabbitConsumerMessage,
+    RabbitConsumerMiddleware,
+    call_middlewares,
+)
 
 # (queue_name, dlq_name, method, props, body, exception)
 MessageErrorCallback = Callable[
@@ -378,8 +382,8 @@ class RabbitMQ:
                     message = RabbitConsumerMessage(
                         routing_key, body, self.body_parser(decoded_body), method, props
                     )
-                    message.call_middlewares(
-                        itertools.chain(list(self.middlewares), [user_consumer])
+                    call_middlewares(
+                        message, itertools.chain(list(self.middlewares), [user_consumer])
                     )
 
                     if not auto_ack:

--- a/rabbitmq_pika_flask/__init__.py
+++ b/rabbitmq_pika_flask/__init__.py
@@ -1,2 +1,18 @@
 from .RabbitMQ import ExchangeType
 from .RabbitMQ import RabbitMQ
+from .RabbitConsumerMessage import (
+    RabbitConsumerMessage,
+    RabbitConsumerMiddleware,
+    RabbitConsumerMiddlewareCallNext,
+    RabbitConsumerMiddlewareError,
+)
+
+
+__all__ = [
+    "ExchangeType",
+    "RabbitMQ",
+    "RabbitConsumerMessage",
+    "RabbitConsumerMiddleware",
+    "RabbitConsumerMiddlewareCallNext",
+    "RabbitConsumerMiddlewareError",
+]

--- a/rabbitmq_pika_flask/__init__.py
+++ b/rabbitmq_pika_flask/__init__.py
@@ -1,6 +1,6 @@
 from .RabbitMQ import ExchangeType
 from .RabbitMQ import RabbitMQ
-from .RabbitConsumerMessage import (
+from .RabbitConsumerMiddleware import (
     RabbitConsumerMessage,
     RabbitConsumerMiddleware,
     RabbitConsumerMiddlewareCallNext,
@@ -12,6 +12,7 @@ __all__ = [
     "ExchangeType",
     "RabbitMQ",
     "RabbitConsumerMessage",
+    "RabbitConsumerMiddleware",
     "RabbitConsumerMiddleware",
     "RabbitConsumerMiddlewareCallNext",
     "RabbitConsumerMiddlewareError",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.28",
+    version="1.2.29",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
This MR adds support for middlewares. Middlewares give us a lot more flexibility when working with message callbacks.


### Usage example

```python
from rabbitmq_pika_flask import RabbitConsumerMessage, RabbitMQ
import logging

logger = logging.getLogger(__file__)

def consumer_logger(message: RabbitConsumerMessage, call_next):
    logger.info(f"Processing rabbit message: {message}")
    try:
        call_next(message)
    except Exception:
        logger.exception("Error while processing message")
    else:
        logger.info("Message processed successfully")

rabbit = RabbitMQ(middlewares=[consumer_logger])
```

### Test Plan
Since this repo doesn't have unittests (or the CI configured for it), I didn't write any.

I simply used `examples/` to test it, by starting rabbitmq locally, adding the middleware above, and sending a message.