### PR TITLE
Accept extra properties for spec.BasicProperties in send and sync_send

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.29",
+    version="1.2.30",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
I have a use case where I need to pass the `correlation_id` to `spec.BasicProperties`. I'm making this change as a more general solution, so we can pass anything we need to it.

## Test Plan

- Start local rabbitmq
- Call send/sync_send with the body, routing key and correlation_id
- Print the data received on the consumer side, and ensure it's as expected