### PR TITLE
Add support for queues with multiple routing keys

### DIFF
--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -180,7 +180,7 @@ class RabbitMQ:
 
     def queue(
         self,
-        routing_key: str,
+        routing_key: str | List[str],
         exchange_type: ExchangeType = ExchangeType.DEFAULT,
         auto_ack: bool = False,
         dead_letter_exchange: bool = False,
@@ -233,7 +233,7 @@ class RabbitMQ:
     def _setup_connection(
         self,
         func: Callable,
-        routing_key: str,
+        routing_key: str | List[str],
         exchange_type: ExchangeType,
         auto_ack: bool,
         dead_letter_exchange: bool,
@@ -285,7 +285,7 @@ class RabbitMQ:
     def _add_exchange_queue(
         self,
         func: Callable,
-        routing_key: str,
+        routing_key: str | List[str],
         exchange_type: ExchangeType,
         auto_ack: bool,
         dead_letter_exchange: bool,
@@ -349,9 +349,11 @@ class RabbitMQ:
         self.app.logger.info(f"Declaring Queue: {queue_name}")
 
         # Bind queue to exchange
-        channel.queue_bind(
-            exchange=self.exchange_name, queue=queue_name, routing_key=routing_key
-        )
+        routing_keys = routing_key if isinstance(routing_key, list) else [routing_key]
+        for routing_key in routing_keys:
+            channel.queue_bind(
+                exchange=self.exchange_name, queue=queue_name, routing_key=routing_key
+            )
 
         def user_consumer(message: RabbitConsumerMessage, call_next) -> None:
             """User consumer as a middleware. Calls the consumer `func`."""

--- a/rabbitmq_pika_flask/RabbitMQ.py
+++ b/rabbitmq_pika_flask/RabbitMQ.py
@@ -180,7 +180,7 @@ class RabbitMQ:
 
     def queue(
         self,
-        routing_key: str | List[str],
+        routing_key: Union[str, List[str]],
         exchange_type: ExchangeType = ExchangeType.DEFAULT,
         auto_ack: bool = False,
         dead_letter_exchange: bool = False,
@@ -189,7 +189,7 @@ class RabbitMQ:
         """Creates new RabbitMQ queue
 
         Args:
-            routing_key (str): The routing key for this queue
+            routing_key (str | list[str]): The routing key(s) for this queue
             exchange_type (ExchangeType, optional): The exchange type to be used. Defaults to TOPIC.
             auto_ack (bool, optional): If messages should be auto acknowledged. Defaults to False
             dead_letter_exchange (bool): If a dead letter exchange should be created for this queue
@@ -233,7 +233,7 @@ class RabbitMQ:
     def _setup_connection(
         self,
         func: Callable,
-        routing_key: str | List[str],
+        routing_key: Union[str, List[str]],
         exchange_type: ExchangeType,
         auto_ack: bool,
         dead_letter_exchange: bool,
@@ -243,7 +243,7 @@ class RabbitMQ:
 
         Args:
             func (Callable): function to run as callback for a new message
-            routing_key (str): routing key for the new queue bind
+            routing_key (str | list[str]): routing key(s) for the new queue bind
             exchange_type (ExchangeType): Exchange type to be used with new queue
             auto_ack (bool): If messages should be auto acknowledged.
             dead_letter_exchange (bool): If a dead letter exchange should be created for this queue
@@ -285,7 +285,7 @@ class RabbitMQ:
     def _add_exchange_queue(
         self,
         func: Callable,
-        routing_key: str | List[str],
+        routing_key: Union[str, List[str]],
         exchange_type: ExchangeType,
         auto_ack: bool,
         dead_letter_exchange: bool,
@@ -295,7 +295,7 @@ class RabbitMQ:
 
         Args:
             func (Callable): function to run as callback for a new message
-            routing_key (str): routing key for the new queue bind
+            routing_key (str | list[str]): routing key(s) for the new queue bind
             exchange_type (ExchangeType): Exchange type to be used with new queue
             auto_ack (bool): If messages should be auto acknowledged.
             dead_letter_exchange (bool): If a dead letter exchange should be created for this queue

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="rabbitmq_pika_flask",
     packages=["rabbitmq_pika_flask"],  # Chose the same as "name"
     # Start with a small number and increase it with every change you make
-    version="1.2.30",
+    version="1.2.31",
     # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     license="MIT",
     # Give a short description about your library


### PR DESCRIPTION
I'd like to do this:

```python
@rabbit.queue(["my.new.routing.key", "my.old.routing.key"])
def my_queue(...):
    ...
```

This PR adds support for that, by allowing multiple routing keys in `@queue`, which are all bound to the created queue.